### PR TITLE
fix(navigation): Preserve cookies during middleware execution

### DIFF
--- a/app/api/pin/clear/route.ts
+++ b/app/api/pin/clear/route.ts
@@ -7,6 +7,7 @@ export async function GET(request: Request) {
   res.cookies.set("pk_pin_ok", "", {
     path: "/protected",
     maxAge: 0,
+    secure: process.env.NODE_ENV === "production",
   });
   return res;
 }

--- a/app/api/pin/route.ts
+++ b/app/api/pin/route.ts
@@ -91,6 +91,7 @@ export async function POST(req: Request) {
     sameSite: "lax",
     path: "/protected",
     maxAge: 5 * 60,
+    secure: process.env.NODE_ENV === "production",
   });
   return res;
 }

--- a/app/api/pin/validate/route.ts
+++ b/app/api/pin/validate/route.ts
@@ -51,6 +51,7 @@ export async function POST(req: Request) {
       sameSite: "lax",
       path: "/",
       maxAge,
+      secure: process.env.NODE_ENV === "production",
     });
     return res;
   }
@@ -84,6 +85,7 @@ export async function POST(req: Request) {
         sameSite: "lax",
         path: "/",
         maxAge: Math.ceil(BLOCK_MS / 1000),
+        secure: process.env.NODE_ENV === "production",
       });
       return res;
     }
@@ -93,6 +95,7 @@ export async function POST(req: Request) {
       sameSite: "lax",
       path: "/",
       maxAge: 60 * 60,
+      secure: process.env.NODE_ENV === "production",
     });
     return res;
   }
@@ -103,6 +106,7 @@ export async function POST(req: Request) {
     sameSite: "lax",
     path: "/protected",
     maxAge: 5 * 60,
+    secure: process.env.NODE_ENV === "production",
   });
   res.cookies.delete(COOKIE_KEY);
   return res;

--- a/app/protected/account/page.tsx
+++ b/app/protected/account/page.tsx
@@ -1,15 +1,4 @@
-import { redirect } from "next/navigation";
-
-import { createClient } from "@/lib/supabase/server";
-
 export default async function AccountSettingsPage() {
-  const supabase = await createClient();
-
-  const { data, error } = await supabase.auth.getClaims();
-  if (error || !data?.claims) {
-    redirect("/auth/login");
-  }
-
   return (
     <div className="flex w-full flex-1 flex-col gap-8">
       <h1 className="text-3xl font-bold">Paramètres du compte</h1>

--- a/app/protected/page.tsx
+++ b/app/protected/page.tsx
@@ -1,19 +1,9 @@
-import { redirect } from "next/navigation";
 import Link from "next/link";
-
-import { createClient } from "@/lib/supabase/server";
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Settings, KeyRound, Users, Podcast } from "lucide-react";
 
 export default async function ProtectedPage() {
-  const supabase = await createClient();
-
-  const { data, error } = await supabase.auth.getClaims();
-  if (error || !data?.claims) {
-    redirect("/auth/login");
-  }
-
   return (
     <div className="flex w-full flex-1 flex-col gap-12">
       <div className="h-8" aria-hidden />

--- a/app/protected/pin/page.tsx
+++ b/app/protected/pin/page.tsx
@@ -1,15 +1,9 @@
-import { redirect } from "next/navigation";
-
 import { createClient } from "@/lib/supabase/server";
 import PinForm from "@/components/protected/PinForm";
 
 export default async function PinSettingsPage() {
   const supabase = await createClient();
-
-  const { data, error } = await supabase.auth.getClaims();
-  if (error || !data?.claims) {
-    redirect("/auth/login");
-  }
+  const { data } = await supabase.auth.getClaims();
 
   const userId = (data as any)?.claims?.sub as string | undefined;
   let mode: "create" | "update" = "create";

--- a/app/protected/podcasts/page.tsx
+++ b/app/protected/podcasts/page.tsx
@@ -1,16 +1,9 @@
-import { redirect } from "next/navigation";
-
 import { createClient } from "@/lib/supabase/server";
 import PodcastsManager from "@/components/protected/PodcastsManager";
 import PodcastsList from "@/components/protected/PodcastsList";
 
 export default async function PodcastsManagementPage() {
   const supabase = await createClient();
-
-  const { data, error } = await supabase.auth.getClaims();
-  if (error || !data?.claims) {
-    redirect("/auth/login");
-  }
 
   const {
     data: { user },

--- a/app/protected/profiles/page.tsx
+++ b/app/protected/profiles/page.tsx
@@ -1,4 +1,3 @@
-import { redirect } from "next/navigation";
 import Link from "next/link";
 
 import { createClient } from "@/lib/supabase/server";
@@ -15,11 +14,7 @@ import {
 
 export default async function ProfilesManagementPage() {
   const supabase = await createClient();
-
-  const { data, error } = await supabase.auth.getClaims();
-  if (error || !data?.claims) {
-    redirect("/auth/login");
-  }
+  const { data } = await supabase.auth.getClaims();
 
   const userId = (data as any)?.claims?.sub as string | undefined;
   let hasPin = false;

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -76,6 +76,15 @@ export async function updateSession(request: NextRequest) {
     }
   }
 
+  // When entering the webplayer, clear the PIN cookie to require a fresh PIN
+  // the next time the user navigates to /protected/*
+  if (path.startsWith("/webplayer")) {
+    supabaseResponse.cookies.set("pk_pin_ok", "", {
+      path: "/protected",
+      maxAge: 0,
+    });
+  }
+
   // IMPORTANT: You *must* return the supabaseResponse object as it is.
   // If you're creating a new response object with NextResponse.next() make sure to:
   // 1. Pass the request in it, like so:

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -46,7 +46,14 @@ export async function updateSession(request: NextRequest) {
   ) {
     const url = request.nextUrl.clone();
     url.pathname = "/auth/login";
-    return NextResponse.redirect(url);
+
+    // IMPORTANT: Preserve cookies set by Supabase during this middleware execution.
+    const redirectResponse = NextResponse.redirect(url);
+    const supaCookies = supabaseResponse.cookies.getAll();
+    for (const c of supaCookies) {
+      redirectResponse.cookies.set(c);
+    }
+    return redirectResponse;
   }
 
   const path = request.nextUrl.pathname;
@@ -60,7 +67,14 @@ export async function updateSession(request: NextRequest) {
       const url = request.nextUrl.clone();
       url.pathname = "/auth/pin";
       url.searchParams.set("redirect", request.nextUrl.pathname + (request.nextUrl.search || ""));
-      return NextResponse.redirect(url);
+
+      // IMPORTANT: Preserve cookies set by Supabase during this middleware execution.
+      const redirectResponse = NextResponse.redirect(url);
+      const supaCookies = supabaseResponse.cookies.getAll();
+      for (const c of supaCookies) {
+        redirectResponse.cookies.set(c);
+      }
+      return redirectResponse;
     }
   }
 


### PR DESCRIPTION
# Description

## The feature / The problem
- Pin code always asked when navigation in /protected/*
- Path by /homapage when navigation in /protected/*

## What I've done / The solution
Durring middleware execution pin cookie was lost. Had it in all middleware requests.
Delete auth call in /protected/* pages to avoid PIN call at every page nav in protected.
Add secure=true to routes in prod

## Type of change
- [ ] New feature (feat)
- [x] Fix issue (fix)
- [ ] Code refactorisation (refactor)
- [ ] Style update (style)
- [ ] Code testing (test)
- [ ] Add documentation (docs)


# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my PR
- [x] I have removed not needed logs
- [x] I have remover TODO comments
- [x] I have commented in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have been able to build my solution locally
- [x] My changes generate no new warnings
- [ ] Access works properly
- [ ] Desktop and mobile styles work properly

# Communication
This solution do not works properly. There is still some case when PIN is asked by navigating in protected/page.
Create new issue to handle it later.